### PR TITLE
Feature/insert update

### DIFF
--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -24,6 +24,8 @@ module.exports = (grunt) ->
 
       query: src: ['test/components/query/*.coffee']
 
+      write: src: ['test/components/write/*.coffee']
+
       dataset: src: ['test/dataset/*.coffee']
 
       mongo: src: ['**/mongo.coffee']
@@ -39,11 +41,14 @@ module.exports = (grunt) ->
 
   grunt.registerTask 'default',
     ['compile', 'mochaTest:common', 'mochaTest:translate', 'mochaTest:facet',
-     'mochaTest:testOptions', 'mochaTest:query', 'mochaTest:dataset']
+     'mochaTest:testOptions', 'mochaTest:query', 'mochaTest:write', 'mochaTest:dataset']
 
-  grunt.registerTask 'mongo', 'mochaTest:mongo'
+  grunt.registerTask 'mongo', ['compile', 'mochaTest:mongo']
 
-  grunt.registerTask 'postgres', 'mochaTest:postgres'
+  grunt.registerTask 'postgres', ['compile', 'mochaTest:postgres']
 
-  grunt.registerTask 'solr', 'mochaTest:solr'
+  grunt.registerTask 'solr', ['compile', 'mochaTest:solr']
 
+  grunt.registerTask 'write', ['compile', 'mochaTest:write']
+
+  grunt.registerTask 'translate', ['compile', 'mochaTest:translate']

--- a/index.js
+++ b/index.js
@@ -4,6 +4,7 @@ translate = require('./lib/translate');
 
 module.exports = {
   components: require('./lib/components'),
+  ACTION_TYPES: common.ACTION_TYPES,
   TYPES: common.TYPES,
   translate: translate,
   toMongo: translate.toMongo,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "franca-js",
-  "version": "0.6.6",
+  "version": "0.7.0",
   "author": "chen.guo.0625@gmail.com",
   "description": "Common query abstraction for multiple data backends",
   "repository": {

--- a/src/common.coffee
+++ b/src/common.coffee
@@ -1,3 +1,21 @@
+_ = require 'lodash'
+
+TYPES =
+  Q: 'Q'
+  AND: 'AND'
+  OR: 'OR'
+  RAW: 'RAW'
+  INSERT: 'INSERT'
+  UPDATE: 'UPDATE'
+  REMOVE: 'REMOVE'
+
+ACTION_TYPES =
+  QUERY: 'ACTION_QUERY'
+  FACET: 'ACTION_FACET'
+  INSERT: 'ACTION_INSERT'
+  UPDATE: 'ACTION_UPDATE'
+  REMOVE: 'ACTION_REMOVE'
+
 ensureNumericValue = (obj, field) ->
   if obj[field]?
     val = parseInt obj[field]
@@ -23,7 +41,7 @@ canonicalizeQuery = (q) ->
   query = switch
     when q.query? then q.query
     when q.filter? then q.filter
-    when not q.facet? then q
+    when not isWrite(q) and not q.facet? then q
     else {}
 
 isAscVal = (v) ->
@@ -36,19 +54,88 @@ isDescVal = (v) ->
     when -1, '-1', 'desc', 'descending' then true
     else false
 
+
+isRaw = (q) ->
+  TYPES.RAW is q.type
+
+isRegularWrite = (q) ->
+  switch q.type
+    when TYPES.INSERT, TYPES.UPDATE, TYPES.REMOVE
+      true
+    else
+      false
+
+isRawWrite = (q) ->
+  return false unless isRaw q
+  switch q.action_type
+    when ACTION_TYPES.INSERT, ACTION_TYPES.UPDATE, ACTION_TYPES.REMOVE
+      true
+    else
+      false
+
+isWrite = (q) ->
+  isRegularWrite(q) or isRawWrite(q)
+
+# classification specifies if it's the regular,
+# raw or either type. Default is 'either'
+validateClassification = (classification) ->
+  return 'either' unless 'string' is typeof classification
+  classification = classification.trim().toLowerCase()
+  switch classification
+    when 'regular', 'raw'
+      classification
+    else
+      'either'
+
+checkRegularType = (q, checkType) ->
+  TYPES[checkType] is q.type
+
+checkRawType = (q, checkType) ->
+  (TYPES.RAW is q.type) and (ACTION_TYPES[checkType] is q.action_type)
+
+commonCheckType = (q, checkType, classification = 'either') ->
+  classification = validateClassification classification
+  switch classification
+    when 'regular'
+      checkRegularType q, checkType
+    when 'raw'
+      checkRawType q, checkType
+    when 'either'
+      (checkRegularType q, checkType) or (checkRawType q, checkType)
+
+isInsert = (q, classification = 'either') ->
+  commonCheckType q, 'INSERT', classification
+
+isUpdate = (q, classification = 'either') ->
+  q.upsert isnt true and commonCheckType q, 'UPDATE', classification
+
+isUpsert = (q, classification = 'either') ->
+  q.upsert is true and commonCheckType q, 'UPDATE', classification
+
+isRemove = (q, classification = 'either') ->
+  commonCheckType q, 'REMOVE', classification
+
+
 module.exports =
-  TYPES:
-    Q: 'Q'
-    AND: 'AND'
-    OR: 'OR'
-    RAW: 'RAW'
+  TYPES: TYPES
+  ACTION_TYPES: ACTION_TYPES
 
   preprocess: (q) ->
-    processed =
-      query: canonicalizeQuery q
-      options: canonicalizeOpts q
-      facet: q.facet
-    return processed
+    q = _.cloneDeep q
+    query = canonicalizeQuery q
+    options = canonicalizeOpts q
+    q.query = query
+    q.options = options
+    return q
+
+  isRegularWrite: isRegularWrite
+  isRawWrite: isRawWrite
+  isWrite: isWrite
+  isRaw: isRaw
+  isInsert: isInsert
+  isUpdate: isUpdate
+  isUpsert: isUpsert
+  isRemove: isRemove
 
   isAscVal: isAscVal
   isDescVal: isDescVal

--- a/src/common.coffee
+++ b/src/common.coffee
@@ -121,7 +121,6 @@ module.exports =
   ACTION_TYPES: ACTION_TYPES
 
   preprocess: (q) ->
-    q = _.cloneDeep q
     query = canonicalizeQuery q
     options = canonicalizeOpts q
     q.query = query

--- a/src/components/facet/postgres.coffee
+++ b/src/components/facet/postgres.coffee
@@ -7,8 +7,8 @@ class PostgresFacet extends BaseFacet
 
   applyFacetField: (queryComponents, facetOpts) ->
     selectFields = facetOpts.field + ', ' + facetOpts.countField
-    queryComponents.SELECT = selectFields
-    queryComponents['GROUP BY'] = facetOpts.field
+    queryComponents.select = selectFields
+    queryComponents.groupBy = facetOpts.field
 
   applyFacetSort: (queryComponents, facetOpts) =>
     if facetOpts.sortBy is @VALUE
@@ -17,7 +17,7 @@ class PostgresFacet extends BaseFacet
       orderBy = facetOpts.countField
     dir = if facetOpts.dir is 1 then @ASC else @DESC
     orderBy += ' ' + dir
-    queryComponents['ORDER BY'] = orderBy
+    queryComponents.orderBy = orderBy
 
   applyFacetImpl: (queryComponents, facetOpts) =>
     facetOpts.countField = "COUNT(#{facetOpts.field})"

--- a/src/components/mongo.coffee
+++ b/src/components/mongo.coffee
@@ -1,19 +1,41 @@
+_ = require 'lodash'
 common = require '../common'
-facet = require './facet'
-query = require './query'
-options = require './options'
+mongoFacet = require('./facet').toMongo
+mongoQuery = require('./query').toMongo
+mongoWrite = require('./write').toMongo
+mongoOptions = require('./options').toMongo
+
+processOptAndQuery = (q, components = {}) ->
+  components.options = mongoOptions q.options, q
+  components.query = mongoQuery q.query
+  return components
+
+processFacetOrWrite = (q, components = {}) ->
+  if common.isRemove q, 'regular'
+    components.remove = components.query
+    delete components.query
+  else if common.isWrite q
+    writes = mongoWrite q
+    components[getWriteCompField q] = writes
+    if common.isUpsert q, 'raw'
+      components = _.merge components, components.update
+  else if q.facet?
+    components = pipeline: mongoFacet components, q.facet
+  return components
+
+getWriteCompField = (q) ->
+  if common.isInsert q then 'insert'
+  else if common.isUpdate(q) or common.isUpsert(q) then 'update'
+  else if common.isRemove q then 'remove'
+  else
+    throw new Error "Invalid Write Type: #{q.type}"
+
 
 module.exports = (q) ->
   q = common.preprocess q
-  opts = options.toMongo q.options
-  if opts.collection?
-    collection = opts.collection
-    delete opts.collection
-  components =
-    query: query.toMongo q.query
-    options: opts
-  if q.facet?
-    components =
-      pipeline: facet.toMongo components, q.facet
+  components = processOptAndQuery q
+  collection = components.options.collection
+  delete components.options.collection
+  components = processFacetOrWrite q, components
   components.collection = collection if collection?
-  return components
+  return _.pick components, (v, k) -> not _.isEmpty v

--- a/src/components/options/mongo.coffee
+++ b/src/components/options/mongo.coffee
@@ -1,4 +1,5 @@
 _ = require 'lodash'
+common = require '../../common'
 BaseOptions = require './options'
 
 class MongoOptions extends BaseOptions
@@ -33,5 +34,14 @@ class MongoOptions extends BaseOptions
       , {}
       return fields: fieldOpts
 
+  multiRowOptions: (opts, q) ->
+    return unless q?
+    if common.isUpdate(q) or common.isUpsert(q)
+      return multi: not opts.singleRow
+    else if common.isRemove q
+      return justOne: !!opts.singleRow
+
+  upsertOptions: (opts, q) ->
+    return upsert: true if q? and common.isUpsert q
 
 module.exports = (new MongoOptions).convertOptions

--- a/src/components/options/options.coffee
+++ b/src/components/options/options.coffee
@@ -18,13 +18,18 @@ class BaseOptions
   formatSortOpts: (opts) =>
     return optsCommon.getSorts opts, @formatSortValue
 
-  convertOptions: (opts) =>
+  multiRowOptions: () -> {}
+
+  upsertOptions: () -> {}
+
+  miscOptions: () -> {}
+
+  convertOptions: (opts, q) =>
     opts = optsCommon.canonicalizeOptions opts
-    rowOpts = @rowOptions opts
-    sortOpts = @sortOptions opts
-    fieldOpts = @fieldOptions opts
-    tableOpts = @tableOptions opts
-    merged = _.merge rowOpts, sortOpts, fieldOpts, tableOpts
-    return merged
+    arrOfOpts = [
+      @rowOptions, @sortOptions, @fieldOptions, @tableOptions,
+      @multiRowOptions, @upsertOptions, @miscOptions
+    ].map (optFn) => optFn.call @, opts, q
+    return _.merge.apply _, arrOfOpts
 
 module.exports = BaseOptions

--- a/src/components/postgres.coffee
+++ b/src/components/postgres.coffee
@@ -1,39 +1,68 @@
 _ = require 'lodash'
 common = require '../common'
-facet = require './facet'
-query = require './query'
-options = require './options'
+pgFacet = require('./facet').toPg
+pgQuery = require('./query').toPg
+pgWrite = require('./write').toPg
+pgOptions = require('./options').toPg
+
+preProcess = (q) ->
+  if common.isUpsert q, 'regular'
+    q.write =
+      query: q.query
+      update: q.write
+    delete q.query
+  common.preprocess q
+
+processOptAndFacet = (q, components = {}) ->
+  components = _.merge components, pgOptions(q.options, q)
+  components = pgFacet components, q.facet if q.facet?
+  return components
+
+processQueryAndWrite = (q, components = {}) ->
+  components = processQuery components, q
+  if common.isWrite q
+    writeComp = pgWrite q
+    if common.isUpsert q, 'regular'
+      components = _.merge components, writeComp
+    else
+      components[getWriteCompField q] = writeComp
+  return components
+
+processQuery = (components, q) ->
+  qStr = pgQuery q.query
+  procFn = if common.isRaw q then processRaw else processWhere
+  procFn components, qStr
 
 processRaw = (components, rawStr) ->
-  # If there are any components, treat raw query
-  # as a WHERE
+  # If there are any components, treat raw query as a WHERE
   if _.isEmpty components
-    components.RAW = rawStr
+    components.raw = rawStr
   else
     components = processWhere components, rawStr
   return components
 
 processWhere = (components, whereStr) ->
-  if not components.FROM?
+  if not components.table?
     throw new Error 'No table specified'
   if whereStr? and whereStr isnt ''
-     components.WHERE = whereStr
+     components.where = whereStr
   return components
 
-processQuery = (components, q) ->
-  qStr = query.toPg q.query
-  if q.query.type is common.TYPES.RAW
-    components = processRaw components, qStr
+getWriteCompField = (q) ->
+  if common.isRaw q
+    'raw'
+  else if common.isInsert(q, 'regular') or common.isUpsert(q, 'regular')
+    'insert'
+  else if common.isUpdate(q, 'regular')
+    'update'
+  else if common.isRemove q, 'regular'
+    'remove'
   else
-    components = processWhere components, qStr
-  return components
+    throw new Error "Invalid Write Type: #{q.type}"
+
 
 module.exports = (q) ->
-  q = common.preprocess q
-  components = {}
-  components = _.merge components, options.toPg q.options
-  if q.facet?
-    components = facet.toPg components, q.facet
-  # Core query treatment depends on options / facets
-  components = processQuery components, q
+  q = preProcess q
+  components = processOptAndFacet q
+  components = processQueryAndWrite q, components
   return components

--- a/src/components/query/base.coffee
+++ b/src/components/query/base.coffee
@@ -36,7 +36,7 @@ class BaseQuery
     return if query? then query else {}
 
   notImplemented: ->
-    throw new Error 'not implemented'
+    throw new Error 'not implemented in Query Component'
 
   # Raw query passthrough
   buildRaw: (q) ->

--- a/src/components/query/postgres.coffee
+++ b/src/components/query/postgres.coffee
@@ -142,9 +142,7 @@ class PostgresQuery extends BaseQuery
   buildRawImpl: (q) ->
     rawQuery = q.raw
     if 'string' is not typeof rawQuery
-      throw new Error 'Raw Solr query is not a string: ' + rawQuery
+      throw new Error 'Raw Postgres query is not a string: ' + rawQuery
     return rawQuery
 
-
 module.exports = (new PostgresQuery).convertQuery
-

--- a/src/components/write/base.coffee
+++ b/src/components/write/base.coffee
@@ -1,0 +1,84 @@
+_ = require 'lodash'
+common = require '../../common'
+
+class BaseWrite
+
+  TYPES: common.TYPES
+
+  notImplemented: (name) ->
+    throw new Error "#{name} not implemented in Write Component"
+
+  convertWrite: (writes) =>
+    writes = common.objectify writes
+    @buildWrite writes
+
+  buildWrite: (writes) ->
+    if common.isRegularWrite writes
+      @buildSimple writes
+    else if common.isRawWrite writes
+      @buildRaw writes
+    else
+      throw new Error "Invalid Write Type: #{writes.type}"
+
+  buildRaw: (writes) ->
+    rawQuery = writes.raw
+    if common.isInsert writes, 'raw'
+      @buildRawInsertImpl writes, rawQuery
+    else if common.isUpdate writes, 'raw'
+      @buildRawUpdateImpl writes, rawQuery
+    else if common.isUpsert writes, 'raw'
+      @buildRawUpsertImpl writes, rawQuery
+    else if common.isRemove writes, 'raw'
+      @buildRawRemoveImpl writes, rawQuery
+
+  buildRawInsertImpl: (writes, rawInsert) ->
+    @notImplemented 'buildRawInsertImpl'
+
+  buildRawUpdateImpl: (writes, rawUpdate) ->
+    @notImplemented 'buildRawUpdateImpl'
+
+  buildRawUpsertImpl: (writes, rawUpsert) ->
+    @notImplemented 'buildRawUpsertImpl'
+
+  buildRawRemoveImpl: (writes, rawRemove) ->
+    @notImplemented 'buildRawRemoveImpl'
+
+  buildSimple: (writes) ->
+    writeQuery = writes.write
+    if common.isInsert writes, 'regular'
+      @buildInsert writes, writeQuery
+    else if common.isUpdate writes, 'regular'
+      @buildUpdate writes, writeQuery
+    else if common.isUpsert writes, 'regular'
+      @buildUpsert writes, writeQuery
+    else if common.isRemove writes, 'regular'
+      @buildRemove writes, writeQuery
+
+  buildInsert: (writes, insertQuery) ->
+    unless _.isArray insertQuery
+      insertQuery = [insertQuery]
+      writes.write = insertQuery
+    @buildInsertImpl writes, insertQuery
+
+  buildUpdate: (writes, updateQuery) ->
+    @buildUpdateImpl writes, updateQuery
+
+  buildUpsert: (writes, upsertQuery) ->
+    @buildUpsertImpl writes, upsertQuery
+
+  buildRemove: (writes, removeQuery) ->
+    @buildRemoveImpl writes, removeQuery
+
+  buildInsertImpl: (writes, insertQuery) ->
+    @notImplemented 'buildInsertImpl'
+
+  buildUpdateImpl: (writes, updateQuery) ->
+    @notImplemented 'buildUpdateImpl'
+
+  buildUpsertImpl: (writes, upsertQuery) ->
+    @notImplemented 'buildUpsertImpl'
+
+  buildRemoveImpl: (writes, removeQuery) ->
+    @notImplemented 'buildRemoveImpl'
+
+module.exports = BaseWrite

--- a/src/components/write/index.coffee
+++ b/src/components/write/index.coffee
@@ -1,0 +1,4 @@
+module.exports =
+  toMongo: require './mongo'
+  toPg: require './postgres'
+  #toSolr: require './solr'

--- a/src/components/write/mongo.coffee
+++ b/src/components/write/mongo.coffee
@@ -1,0 +1,47 @@
+_ = require 'lodash'
+BaseWrite = require './base'
+
+class MongoWrite extends BaseWrite
+
+  buildRawInsertImpl: (writes, rawInsert) ->
+    @buildMongoRawQuery rawInsert, 'Insert'
+
+  buildRawUpdateImpl: (writes, rawUpdate) ->
+    @buildMongoRawQuery rawUpdate, 'Update'
+
+  buildRawUpsertImpl: (writes, rawUpsert) ->
+    @buildMongoRawQuery rawUpsert, 'Upsert'
+
+  buildRawRemoveImpl: (writes, rawRemove) ->
+    @buildMongoRawQuery rawRemove, 'Remove'
+
+  buildMongoRawQuery: (rawQuery, queryName) ->
+    if 'string' is typeof rawQuery
+      try
+        raw = JSON.parse rawQuery
+      catch e
+        throw new Error "Failed parsing Mongo Raw #{queryName} string: #{e}"
+    else if rawQuery instanceof Object
+      raw = rawQuery
+    unless raw?
+      throw new Error "Mongo Raw #{queryName} isn't a valid JSON string or object: #{rawQuery}"
+    raw
+
+  buildInsertImpl: (writes, insertQuery) ->
+    if insertQuery.every((insert) -> _.isObject insert)
+      insertQuery
+    else
+      throw new Error "Invalid insert object: #{JSON.stringify insertQuery}"
+
+  buildUpdateImpl: (writes, updateQuery) ->
+    if _.isObject updateQuery
+      return $set: updateQuery
+    else
+      throw new Error "Invalid update object: #{JSON.stringify updateQuery}"
+
+  buildUpsertImpl: (writes, upsertQuery) ->
+    @buildUpdate writes, upsertQuery
+
+  buildRemoveImpl: (writes, removeQuery) ->
+
+module.exports = (new MongoWrite).convertWrite

--- a/src/components/write/postgres.coffee
+++ b/src/components/write/postgres.coffee
@@ -1,0 +1,85 @@
+_ = require 'lodash'
+BaseWrite = require './base'
+
+class PostgresWrite extends BaseWrite
+
+  pgValStringify: (val) ->
+    if typeof val is 'string'
+      val = "'#{val}'"
+    else if val is undefined
+      val = null
+    "#{val}"
+
+  buildRawInsertImpl: (writes, rawInsert) ->
+    @buildPostgresRawQuery rawInsert, 'Insert'
+
+  buildRawUpdateImpl: (writes, rawUpdate) ->
+    @buildPostgresRawQuery rawUpdate, 'Update'
+
+  buildRawUpsertImpl: (writes, rawUpsert) ->
+    @buildPostgresRawQuery rawUpsert, 'Upsert'
+
+  buildRawRemoveImpl: (writes, rawRemove) ->
+    @buildPostgresRawQuery rawRemove, 'Remove'
+
+  buildPostgresRawQuery: (rawQuery, queryName) ->
+    if 'string' isnt typeof rawQuery
+      throw new Error "Raw Postgres #{queryName} is not a string: #{rawQuery}"
+    rawQuery
+
+  buildInsertImpl: (writes, insertQuery) ->
+    fieldsLists = insertQuery.map _.keys
+    insertFields = _.union.apply _, fieldsLists
+    insertValStrs = insertQuery.map (insert) =>
+      valStr = insertFields
+        .map((field) => @pgValStringify insert[field])
+        .join ', '
+      "(#{valStr})"
+    insertValString = insertValStrs.join ', '
+    insertFieldString = "(#{insertFields.join ', '})"
+    "#{insertFieldString} VALUES #{insertValString}"
+
+  buildUpdateImpl: (writes, updateQuery) ->
+    fieldVals = _.map(updateQuery, (value, field) => "#{field} = #{@pgValStringify value}")
+    fieldVals.join ', '
+
+  # For simple query only,
+  # like simple match or AND in UPSERT query
+  translateSimpleQuery: (q) ->
+    switch q.type
+      when @TYPES.RAW, @TYPES.OR
+        throw new Error "Simple Query only supports simple match or AND query"
+      when @TYPES.AND
+        if q.negate or q.queries.some((subQ) -> q.negate)
+          throw new Error "Simple Query supports no negate query"
+        andQueries = q.queries.map (subQ) => @translateSimpleQuery subQ
+        return _.merge.apply _, andQueries
+      else
+        unless q.field? and q.match?
+          throw new Error "Simple Query only supports match query"
+        if _.isArray(q.match) and q.match.length > 1
+          throw new Error "Simple Query only supports one single match query"
+        singleQuery = {}
+        matchVal = if _.isArray(q.match) then q.match[0] else q.match
+        singleQuery[q.field] = matchVal
+        return singleQuery
+
+  buildUpsertImpl: (writes, upsertQuery) ->
+    queryDoc = @translateSimpleQuery upsertQuery.query
+    updateDoc = upsertQuery.update
+    conflictFields = _.keys queryDoc
+    intersectFields = _.intersection conflictFields, _.keys updateDoc
+    if intersectFields.some((field) -> queryDoc[field] isnt updateDoc[field])
+      throw new Error "Query and Update doc cannot have collided key/val in UPSERT"
+    updateDoc = _.pick updateDoc, (value, field) ->
+      not _.includes intersectFields, field
+    insertStatement = @buildInsert writes, _.merge(queryDoc, updateDoc)
+    updateStatement = @buildUpdate writes, updateDoc
+    upsertStates =
+      insert: insertStatement
+      conflict: "(#{conflictFields.join ', '})"
+      update: updateStatement
+
+  buildRemoveImpl: (writes, removeQuery) -> ""
+
+module.exports = (new PostgresWrite).convertWrite

--- a/src/translate/mongo.coffee
+++ b/src/translate/mongo.coffee
@@ -1,7 +1,10 @@
 _ = require 'lodash'
 components = require '../components'
 
-KEYS = ['query', 'options', 'pipeline', 'collection']
+KEYS = [
+  'query', 'insert', 'update', 'remove',
+  'options', 'pipeline', 'collection'
+]
 
 module.exports = (q) ->
   c = components.toMongo q

--- a/src/translate/postgres.coffee
+++ b/src/translate/postgres.coffee
@@ -1,20 +1,91 @@
-components = require '../components'
+_ = require 'lodash'
+common = require '../common'
+pgComponents = require('../components').toPg
 
-CLAUSES = ['SELECT', 'FROM', 'WHERE', 'GROUP BY', 'ORDER BY',
-           'LIMIT', 'OFFSET']
+CLAUSE_MAPPING =
+  query:
+    fields:
+      ['select', 'table', 'where', 'groupBy',
+      'orderBy', 'limit', 'offset']
+    clauseMap:
+      select: 'SELECT'
+      table: 'FROM'
+      where: 'WHERE'
+      groupBy: 'GROUP BY'
+      orderBy: 'ORDER BY'
+      limit: 'LIMIT'
+      offset: 'OFFSET'
+  insert:
+    fields: ['table', 'insert', 'conflict', 'update']
+    clauseMap:
+      table: 'INSERT INTO'
+      conflict: 'ON CONFLICT'
+      update: 'DO UPDATE SET'
+  update:
+    fields: ['table', 'update', 'where']
+    clauseMap:
+      table: 'UPDATE'
+      update: 'SET'
+      where: 'WHERE'
+  remove:
+    fields: ['table', 'where']
+    clauseMap:
+      table: 'DELETE FROM'
+      where: 'WHERE'
 
-combineComponents = (components) ->
-  return components.RAW if components.RAW?
-  components.SELECT ?= '*'
-  pgQuery = CLAUSES.reduce (str, c) ->
+clauseValCombiner = (components, fields, clauseMap) ->
+  valsWithClauses = fields.map (c) ->
     val = components[c]
     if val? and val isnt ''
-      str += ' ' if str isnt ''
-      str += "#{c} #{val}"
-    return str
-  , ''
-  return pgQuery
+      clause = clauseMap[c] or ''
+      clause += ' ' if clause isnt ''
+      val = clause + val
+    val
+  valsWithClauses
+    .filter((v) -> not _.isEmpty v)
+    .join ' '
 
-module.exports = (q) ->
-  translated = combineComponents components.toPg q
+getClauseMap = (q) ->
+  if common.isInsert(q, 'regular') or common.isUpsert(q, 'regular')
+    clauseField = 'insert'
+  else if common.isUpdate q, 'regular'
+    clauseField = 'update'
+  else if common.isRemove q, 'regular'
+    clauseField = 'remove'
+  else
+    clauseField = 'query'
+  CLAUSE_MAPPING[clauseField]
+
+combineComponents = (transComps, q) ->
+  return transComps.raw if transComps.raw?
+  transComps.select ?= '*'
+  clauses = getClauseMap q
+  clauseValCombiner transComps, clauses.fields, clauses.clauseMap
+
+getPickFirstRowQuery = (q, primField) ->
+  q.options ?= {}
+  opt = q.options
+  opt.fields = [primField]
+  opt.sort = [[primField, 1]]
+  opt.limit = 1
+  "#{primField} = (#{pgTranslate q})"
+
+processSubQuery = (transComps, q) ->
+  if transComps.singleRowField?
+    subQ = _.cloneDeep q
+    delete subQ.options.singleRow
+    if common.isWrite subQ
+      delete subQ.type
+      delete subQ.action_type
+      delete subQ.write
+    transComps.where = getPickFirstRowQuery subQ, transComps.singleRowField
+  transComps
+
+pgTranslate = (q) ->
+  translatedComponents = pgComponents q
+  translatedComponents = processSubQuery translatedComponents, q
+  translated = combineComponents translatedComponents, q
   return translated
+
+
+module.exports = pgTranslate

--- a/test/common.coffee
+++ b/test/common.coffee
@@ -1,4 +1,4 @@
-require 'should'
+should = require 'should'
 _ = require 'lodash'
 
 negateQuery = (q) ->
@@ -6,12 +6,15 @@ negateQuery = (q) ->
   negated.negate = not q.negate
   return negated
 
+translatedTester = (translated, expected) ->
+  if translated instanceof Object
+    translated.should.be.eql expected
+  else
+    should.equal translated, expected # in case the translated is null or undefined
+
 testTranslation = (translator, expected, query) ->
   translated = translator query
-  if translated instanceof Object
-    expected.should.be.eql translated
-  else
-    expected.should.be.equal translated
+  translatedTester translated, expected
 
 module.exports =
   negateSpec: negateQuery
@@ -23,6 +26,14 @@ module.exports =
       query = tests[key]
       expected = translations[key]
       testTranslation translator, expected, query
+
+  makeSpecifiedFieldTesterWithQuery: (tests, translator, translations, field) ->
+    return (key) ->
+      query = tests[key]
+      specifiedVal = query[field]
+      expected = translations[key]
+      translated = translator specifiedVal, query
+      translatedTester translated, expected
 
   makeNegateQueryTester: (queries, translator, negatedTranslations) ->
     return (key) ->

--- a/test/components/facet/postgres.coffee
+++ b/test/components/facet/postgres.coffee
@@ -8,42 +8,42 @@ testCases = require './test-cases'
 testTable = 'tab'
 translations =
   basic:
-    SELECT: 'category, COUNT(category)'
-    FROM: testTable
-    'GROUP BY': 'category'
-    'ORDER BY': 'COUNT(category) DESC'
+    select: 'category, COUNT(category)'
+    table: testTable
+    groupBy: 'category'
+    orderBy: 'COUNT(category) DESC'
 
   withLimit:
-    SELECT: 'category, COUNT(category)'
-    FROM: testTable
-    'GROUP BY': 'category'
-    'ORDER BY': 'COUNT(category) DESC'
-    LIMIT: 100
+    select: 'category, COUNT(category)'
+    table: testTable
+    groupBy: 'category'
+    orderBy: 'COUNT(category) DESC'
+    limit: 100
 
   countAsc:
-    SELECT: 'category, COUNT(category)'
-    FROM: testTable
-    'GROUP BY': 'category'
-    'ORDER BY': 'COUNT(category) ASC'
+    select: 'category, COUNT(category)'
+    table: testTable
+    groupBy: 'category'
+    orderBy: 'COUNT(category) ASC'
 
   byValue:
-    SELECT: 'category, COUNT(category)'
-    FROM: testTable
-    'GROUP BY': 'category'
-    'ORDER BY': 'category ASC'
+    select: 'category, COUNT(category)'
+    table: testTable
+    groupBy: 'category'
+    orderBy: 'category ASC'
 
   valueDesc:
-    SELECT: 'category, COUNT(category)'
-    FROM: testTable
-    'GROUP BY': 'category'
-    'ORDER BY': 'category DESC'
+    select: 'category, COUNT(category)'
+    table: testTable
+    groupBy: 'category'
+    orderBy: 'category DESC'
 
   withQuery:
-    SELECT: 'category, COUNT(category)'
-    FROM: testTable
-    WHERE: "difficulty = 'high'"
-    'GROUP BY': 'category'
-    'ORDER BY': 'COUNT(category) DESC'
+    select: 'category, COUNT(category)'
+    table: testTable
+    where: "difficulty = 'high'"
+    groupBy: 'category'
+    orderBy: 'COUNT(category) DESC'
 
 
 facetTester = (key) ->

--- a/test/components/options/mongo.coffee
+++ b/test/components/options/mongo.coffee
@@ -16,6 +16,13 @@ translations =
       area: 1
       weight: 1
   sortArr: sort: [['name', -1], ['address', 1]]
+  singleUpdate: multi: false
+  mongoMultipleUpsert:
+    upsert: true
+    multi: true
+  singleRemove: justOne: true
+  multipleRemove: justOne: false
+
 
 translations.sortObj = translations.sortArr
 translations.combined =
@@ -26,6 +33,7 @@ translations.combined =
 
 
 testOptions = common.makeTester testCases, options.toMongo, translations
+testOptionsWithQuery = common.makeSpecifiedFieldTesterWithQuery testCases, options.toMongo, translations, 'options'
 
 describe 'Mongo options tests', () ->
 
@@ -55,3 +63,15 @@ describe 'Mongo options tests', () ->
       table: 'myCollection'
     expected = collection: 'myCollection'
     common.testTranslation options.toMongo, expected, colQuery
+
+  it 'should translate to just one update', () ->
+    testOptionsWithQuery 'singleUpdate'
+
+  it 'should translate to multiple upsert', () ->
+    testOptionsWithQuery 'mongoMultipleUpsert'
+
+  it 'should translate to just one delete', () ->
+    testOptionsWithQuery 'singleRemove'
+
+  it 'should translate to multiple delete', () ->
+    testOptionsWithQuery 'multipleRemove'

--- a/test/components/options/postgres.coffee
+++ b/test/components/options/postgres.coffee
@@ -7,19 +7,19 @@ common = require '../../common'
 
 testTable = 'pgTable'
 translations =
-  empty: FROM: testTable
+  empty: table: testTable
   offset:
-    FROM: testTable
-    OFFSET: 100
+    table: testTable
+    offset: 100
   limit:
-    FROM: testTable
-    LIMIT: 10
+    table: testTable
+    limit: 10
   fields:
-    FROM: testTable
-    SELECT: 'volume, area, weight'
+    table: testTable
+    select: 'volume, area, weight'
   sortArr:
-    FROM: testTable
-    'ORDER BY': 'name DESC, address ASC'
+    table: testTable
+    orderBy: 'name DESC, address ASC'
 
 translations.sortObj = translations.sortArr
 translations.combined =

--- a/test/components/options/test-cases.coffee
+++ b/test/components/options/test-cases.coffee
@@ -1,4 +1,5 @@
 _ = require 'lodash'
+TYPES = require('../../../lib/common').TYPES
 
 limit = limit: 10
 offset = offset: 100
@@ -8,6 +9,8 @@ sortObj =
   sort:
     name: 'Descending'
     address: 'asc'
+single = singleRow: true
+multiple = singleRow: false
 
 module.exports =
   empty: {}
@@ -17,3 +20,22 @@ module.exports =
   sortArr: sortArr
   sortObj: sortObj
   combined: _.merge {}, offset, limit, fields, sortArr
+  singleUpdate:
+    type: TYPES.UPDATE
+    query: {}
+    write: {}
+    options: single
+  mongoMultipleUpsert:
+    type: TYPES.UPDATE
+    upsert: true
+    query: {}
+    write: {}
+    options: multiple
+  singleRemove:
+    type: TYPES.REMOVE
+    query: {}
+    options: single
+  multipleRemove:
+    type: TYPES.REMOVE
+    query: {}
+    options: multiple

--- a/test/components/write/mongo.coffee
+++ b/test/components/write/mongo.coffee
@@ -1,0 +1,57 @@
+require 'should'
+testCases = require './test-cases'
+common = require '../../common'
+TYPES = require('../../../lib/common').TYPES
+ACTION_TYPES = require('../../../lib/common').ACTION_TYPES
+mongoWrite = require('../../../lib/components/write').toMongo
+
+
+# Translations
+translations =
+  basicInsert: [testCases.basicInsert.write]
+  multiInserts: testCases.multiInserts.write
+  update: $set: testCases.update.write
+  mongoUpsert: $set: testCases.mongoUpsert.write
+  remove: undefined
+
+rawWrites = [
+  type: TYPES.RAW
+  action_type: ACTION_TYPES.INSERT
+  raw: [ testCases.simpleDoc1, testCases.simpleDoc2 ]
+,
+  type: TYPES.RAW
+  action_type: ACTION_TYPES.UPDATE
+  raw:
+    query: testCases.simpleDoc1
+    update: $set: testCases.updateDoc1
+,
+  type: TYPES.RAW
+  action_type: ACTION_TYPES.REMOVE
+  raw: testCases.simpleDoc1
+]
+
+
+testWrite = common.makeTester testCases, mongoWrite, translations
+
+
+describe 'Mongo write tests', () ->
+
+  it 'should translate a single insert', () ->
+    testWrite 'basicInsert'
+
+  it 'should translate a multi inserts', () ->
+    testWrite 'multiInserts'
+
+  it 'should translate an update', () ->
+    testWrite 'update'
+
+  it 'should translate an upsert', () ->
+    testWrite 'mongoUpsert'
+
+  it 'should translate a remove', () ->
+    testWrite 'remove'
+
+  for raw in rawWrites
+    it "should not translate the #{raw.type} query", () ->
+      translated = mongoWrite raw
+      translated.should.be.eql raw.raw

--- a/test/components/write/postgres.coffee
+++ b/test/components/write/postgres.coffee
@@ -1,0 +1,60 @@
+require 'should'
+testCases = require './test-cases'
+common = require '../../common'
+TYPES = require('../../../lib/common').TYPES
+ACTION_TYPES = require('../../../lib/common').ACTION_TYPES
+pgWrite = require('../../../lib/components/write').toPg
+
+
+# Translations
+translations =
+  basicInsert: "(name, address) VALUES ('Bill', 'LA')"
+  multiInserts: "(name, address, country) VALUES ('Bill', 'LA', null), ('Jack', 'NY', 'US')"
+  update: "address = 'NY', country = 'US'"
+  pgUpsert:
+    insert: "(name, address, country) VALUES ('Bill', 'NY', 'US')"
+    conflict: "(name, address)"
+    update: "country = 'US'"
+  remove: ""
+
+rawWrites = [
+  type: TYPES.RAW
+  action_type: ACTION_TYPES.INSERT
+  raw: "INSERT INTO test-table (name, address) VALUES ('Bill', 'LA')"
+,
+  type: TYPES.RAW
+  action_type: ACTION_TYPES.UPDATE
+  raw: "UPDATE test-table SET name='Bill', address='LA' WHERE id='001'"
+,
+  type: TYPES.RAW
+  action_type: ACTION_TYPES.REMOVE
+  raw: "DELETE FROM test-table WHERE name='Bill', address='LA'"
+]
+
+testWrite = common.makeTester testCases, pgWrite, translations
+
+
+describe 'Postgres write tests', () ->
+
+  it 'should translate a single insert', () ->
+    testWrite 'basicInsert'
+
+  it 'should translate a multiple inserts', () ->
+    testWrite 'multiInserts'
+
+  it 'should translate an update', () ->
+    testWrite 'update'
+
+  it 'should translate an upsert', () ->
+    testWrite 'pgUpsert'
+
+  it 'should throw error when query and update collided for Pg upsert', () ->
+    pgWrite.bind(null, testCases.pgUpsertInvalid).should.throw()
+
+  it 'should translate an remove', () ->
+    testWrite 'remove'
+
+  for raw in rawWrites
+    it "should not translate the #{raw.type} query", () ->
+      translated = pgWrite raw
+      translated.should.be.eql raw.raw

--- a/test/components/write/test-cases.coffee
+++ b/test/components/write/test-cases.coffee
@@ -1,0 +1,80 @@
+common = require '../../../lib/common'
+TYPES = common.TYPES
+
+simpleDoc1 =
+  name: 'Bill'
+  address: 'LA'
+
+queryDoc1 =
+  type: TYPES.AND
+  queries: [
+    field: 'name'
+    match: 'Bill'
+  ,
+    field: 'address'
+    match: 'LA'
+  ]
+
+updateDoc1 =
+  address: 'NY'
+  country: 'US'
+
+simpleDoc2 =
+  name: 'Jack'
+  address: 'NY'
+  country: 'US'
+
+queryDoc2 =
+  type: TYPES.AND
+  queries: [
+    field: 'name'
+    match: 'Bill'
+  ,
+    field: 'address'
+    match: 'NY'
+  ]
+
+
+module.exports =
+  simpleDoc1: simpleDoc1
+  queryDoc1: queryDoc1
+  updateDoc1: updateDoc1
+  simpleDoc2: simpleDoc2
+  queryDoc2: queryDoc2
+
+  basicInsert:
+    type: TYPES.INSERT
+    write: simpleDoc1
+
+  multiInserts:
+    type: TYPES.INSERT
+    write: [ simpleDoc1, simpleDoc2 ]
+
+  update:
+    type: TYPES.UPDATE
+    query: queryDoc1
+    write: updateDoc1
+
+  mongoUpsert:
+    type: TYPES.UPDATE
+    upsert: true
+    query: queryDoc1
+    write: updateDoc1
+
+  pgUpsert:
+    type: TYPES.UPDATE
+    upsert: true
+    write:
+      query: queryDoc2
+      update: updateDoc1
+
+  pgUpsertInvalid:
+    type: TYPES.UPDATE
+    upsert: true
+    write:
+      query: queryDoc1
+      update: updateDoc1
+
+  remove:
+    type: TYPES.REMOVE
+    query: queryDoc1

--- a/test/translate/mongo.coffee
+++ b/test/translate/mongo.coffee
@@ -1,6 +1,8 @@
 common = require '../common'
 franca = require '../../index'
 testCases = require './test-cases'
+TYPES = require('../../lib/common').TYPES
+ACTION_TYPES = require('../../lib/common').ACTION_TYPES
 
 translations =
   sampleQuery:
@@ -24,6 +26,82 @@ translations =
       $sort: _id: 1
     ]
 
+  insertWrite:
+    collection: testCases.testTable
+    insert: testCases.insertWrite.write
+
+  updateWrite:
+    collection: testCases.testTable
+    query: testCases.simplifiedQueryDoc1
+    update: $set: testCases.updateWrite.write
+    options: multi: false
+
+  mongoUpsertWrite:
+    collection: testCases.testTable
+    query: testCases.simplifiedQueryDoc1
+    update: $set: testCases.mongoUpsertWrite.write
+    options:
+      upsert: true
+      multi: true
+
+  removeWrite:
+    collection: testCases.testTable
+    remove: testCases.simplifiedQueryDoc1
+    options: justOne: true
+
+rawInsertDoc = [
+  name: 'Bill'
+  address: 'LA'
+,
+  name: 'Jack'
+  address: 'NY'
+  country: 'US'
+]
+
+rawQueryDoc =
+  name: 'Bill'
+  address: 'LA'
+
+rawUpdateDoc =
+  $set:
+    address: 'NY'
+    country: 'US'
+
+rawTranslations = [
+  query:
+    type: TYPES.RAW
+    action_type: ACTION_TYPES.INSERT
+    raw: rawInsertDoc
+  translate:
+    insert: rawInsertDoc
+,
+  query:
+    type: TYPES.RAW
+    action_type: ACTION_TYPES.UPDATE
+    raw: query: rawQueryDoc, update: rawUpdateDoc
+  translate:
+    query: rawQueryDoc
+    update: rawUpdateDoc
+,
+  query:
+    type: TYPES.RAW
+    action_type: ACTION_TYPES.UPDATE
+    upsert: true
+    raw: query: rawQueryDoc, update: rawUpdateDoc
+  translate:
+    query: rawQueryDoc
+    update: rawUpdateDoc
+    options: upsert: true
+,
+  query:
+    type: TYPES.RAW
+    action_type: ACTION_TYPES.REMOVE
+    raw: rawQueryDoc
+  translate:
+    remove: rawQueryDoc
+    options: justOne: false
+]
+
 testFn = common.makeTester testCases, franca.toMongo, translations
 
 describe 'Mongo integration tests', () ->
@@ -37,3 +115,20 @@ describe 'Mongo integration tests', () ->
 
   it 'translate a Mongo facet', () ->
     testFn 'sampleFacet'
+
+  it 'translate a Mongo insert', () ->
+    testFn 'insertWrite'
+
+  it 'translate a Mongo update', () ->
+    testFn 'updateWrite'
+
+  it 'translate a Mongo upsert', () ->
+    testFn 'mongoUpsertWrite'
+
+  it 'translate a Mongo remove', () ->
+    testFn 'removeWrite'
+
+  for raw in rawTranslations
+    it "translate a Mongo raw #{raw.query.type}", () ->
+      translated = franca.toMongo raw.query
+      translated.should.be.eql raw.translate

--- a/test/translate/postgres.coffee
+++ b/test/translate/postgres.coffee
@@ -2,11 +2,41 @@ require 'should'
 common = require '../common'
 franca = require '../../index'
 testCases = require './test-cases'
+TYPES = require('../../lib/common').TYPES
+ACTION_TYPES = require('../../lib/common').ACTION_TYPES
 
 translations =
   sampleQuery: "SELECT * FROM #{testCases.testTable} WHERE price <= 100 LIMIT 10 OFFSET 50"
   compoundQuery: "SELECT brand, size FROM #{testCases.testTable} WHERE (type = 'pants' AND price <= 100)"
   sampleFacet: "SELECT city, COUNT(city) FROM #{testCases.testTable} WHERE population >= 1000000 GROUP BY city ORDER BY city ASC"
+  insertWrite: "INSERT INTO #{testCases.testTable} (field1, field2, field3) VALUES ('foo1', 'bar1', null), ('foo2', 'bar2', 'test3')"
+  updateWrite: "UPDATE #{testCases.testTable} SET field1 = 'foo2', field2 = 'bar2', field3 = 'test3' WHERE id = (SELECT id FROM #{testCases.testTable} WHERE (field1 = 'foo1' AND field2 = 'bar1') ORDER BY id ASC LIMIT 1)"
+  pgUpsertWrite: "INSERT INTO #{testCases.testTable} (field1, field2, field3, field4) VALUES ('foo1', 'bar1', 'test3', 'test4') ON CONFLICT (field1, field2) DO UPDATE SET field3 = 'test3', field4 = 'test4'"
+  removeWrite: "DELETE FROM #{testCases.testTable} WHERE id = (SELECT id FROM #{testCases.testTable} WHERE (field1 = 'foo1' AND field2 = 'bar1') ORDER BY id ASC LIMIT 1)"
+
+rawInsertDoc = "INSERT INTO test-table (name, address) VALUES ('Bill', 'LA')"
+rawUpdateDoc = "UPDATE test-table SET name='Bill', address='LA' WHERE id='001'"
+rawRemoveDoc = "DELETE FROM test-table WHERE name='Bill', address='LA'"
+
+rawTranslations = [
+  query:
+    type: TYPES.RAW
+    action_type: ACTION_TYPES.INSERT
+    raw: rawInsertDoc
+  translate: rawInsertDoc
+,
+  query:
+    type: TYPES.RAW
+    action_type: ACTION_TYPES.UPDATE
+    raw: rawUpdateDoc
+  translate: rawUpdateDoc
+,
+  query:
+    type: TYPES.RAW
+    action_type: ACTION_TYPES.REMOVE
+    raw: rawRemoveDoc
+  translate: rawRemoveDoc
+]
 
 testFn = common.makeTester testCases, franca.toPg, translations
 
@@ -45,3 +75,23 @@ describe 'Postgres integration tests', () ->
         table: testCases.testTable
     translated = franca.toPg rawQuery
     translated.should.be.eql "SELECT * FROM #{testCases.testTable} WHERE #{rawWhere}"
+
+  it 'translate a Postgres insert', () ->
+    testFn 'insertWrite'
+
+  it 'translate a Postgres update', () ->
+    testFn 'updateWrite'
+
+  it 'translate a Postgres upsert', () ->
+    testFn 'pgUpsertWrite'
+
+  it 'should throw error when query and update collided for Pg upsert', () ->
+    franca.toPg.bind(null, testCases.pgUpsertWriteInvalid).should.throw()
+
+  it 'translate a Postgres remove', () ->
+    testFn 'removeWrite'
+
+  for raw in rawTranslations
+    it "translate a Postgres raw #{raw.query.type}", () ->
+      translated = franca.toPg raw.query
+      translated.should.be.eql raw.translate

--- a/test/translate/test-cases.coffee
+++ b/test/translate/test-cases.coffee
@@ -1,5 +1,42 @@
 franca = require '../../index'
 testTable = 'tab'
+TYPES = franca.TYPES
+
+insertDoc = [
+  field1: 'foo1'
+  field2: 'bar1'
+,
+  field1: 'foo2'
+  field2: 'bar2'
+  field3: 'test3'
+]
+
+queryDoc1 =
+  type: TYPES.AND
+  queries: [
+    field: 'field1'
+    match: 'foo1'
+  ,
+    field: 'field2',
+    match: 'bar1'
+  ]
+
+simplifiedQueryDoc1 =
+  $and: [
+    field1: 'foo1'
+  ,
+    field2: 'bar1'
+  ]
+
+updateDoc1 =
+  field1: 'foo2'
+  field2: 'bar2'
+  field3: 'test3'
+
+updateDoc2 =
+  field2: 'bar1'
+  field3: 'test3'
+  field4: 'test4'
 
 module.exports =
 
@@ -11,12 +48,12 @@ module.exports =
       limit: 10
       table: testTable
     query:
-      type: franca.TYPES.Q
+      type: TYPES.Q
       field: 'price'
       range: lte: 100
 
   compoundQuery:
-    type: franca.TYPES.AND
+    type: TYPES.AND
     options:
       fields: ['brand', 'size']
       table: testTable
@@ -28,7 +65,6 @@ module.exports =
       range: lte: 100
     ]
 
-
   sampleFacet:
     facet:
       field: 'city'
@@ -39,6 +75,52 @@ module.exports =
     table: testTable
 
   noTable:
-    type: franca.TYPES.Q
+    type: TYPES.Q
     field: 'price'
     match: 100
+
+  simplifiedQueryDoc1: simplifiedQueryDoc1
+
+  insertWrite:
+    type: TYPES.INSERT
+    write: insertDoc
+    table: testTable
+
+  updateWrite:
+    type: TYPES.UPDATE
+    query: queryDoc1
+    write: updateDoc1
+    options:
+      table: testTable
+      singleRow: true
+      primaryField: 'id'
+
+  mongoUpsertWrite:
+    type: TYPES.UPDATE
+    upsert: true
+    query: queryDoc1
+    write: updateDoc1
+    options: table: testTable
+
+  pgUpsertWrite:
+    type: TYPES.UPDATE
+    upsert: true
+    query: queryDoc1
+    write: updateDoc2
+    options:
+      table: testTable
+
+  pgUpsertWriteInvalid:
+    type: TYPES.UPDATE
+    upsert: true
+    query: queryDoc1
+    write: updateDoc1
+    options: table: testTable
+
+  removeWrite:
+    type: TYPES.REMOVE
+    table: testTable
+    query: queryDoc1
+    options:
+      singleRow: true
+      primaryField: 'id'


### PR DESCRIPTION
@chen-factual 

Could you help me have a look at this? I understand there're a lot of these, but they're hard to be split, even one change is involved in different backends, and have to be changed in both component and translate.

Majore changes I made:
0.) New component called `write`
1.) A bunch of functions in `common.coffee` to detect actual write type
2.) The keys of Postgres components results are camel name instead of SQL clause key word
3.) More options process functions to handle more opts
4.) Refactor Mongo & Postgres component, so that they can process different types, and return appropriate results
5.) Refactor Postgres translate, so that it can assemble the finale SQL statement according to different returned keys. Especially I added a function to process sub query, which will generate new queries, send it to Postgres component and set that result as the `where` clause value.
6.) Add and improve tests

Note that I added a new type called `ACTION_TYPES`, as what you suggested before, to indicate the actual raw type(insert, update or remove). But about this, I still think we can detect the raw type by specifying different raw doc field, like `{"raw": {}}`, `{"raw-insert": {}}`, this looks simpler because we don't have to add a new type. What do you think about it?
